### PR TITLE
[PKG-4870] keplergl 0.3.2 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   script:
     - {{ PYTHON }} -m pip install . -vv
-  skip: true  # [py<37]
+  skip: true  # [py<37 or s390x]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,16 +22,14 @@ requirements:
     - pip
     - jupyter
     - jupyter-packaging
-    - pandas
-    - geopandas
     - wheel
   run:
     - python
-    - ipywidgets ==7.8.1
+    - ipywidgets >=7.0.0,<8
     - traittypes >=0.2.1
-    - pandas >=1.3.1
-    - geopandas >=0.9.0
-    - shapely >=1.7.1
+    - pandas >=0.23.0
+    - geopandas >=0.5.0
+    - shapely >=1.6.4.post2
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script:
-    - {{ PYTHON }} -m pip install . -vv
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<37 or s390x]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,8 @@ requirements:
     - geopandas
   run:
     - python >=3.6
-    - ipywidgets >=7.6.3
+    # build fails with most recent version
+    - ipywidgets ==7.8.1
     - traittypes >=0.2.1
     - pandas >=1.3.1
     - geopandas >=0.9.0
@@ -34,8 +35,12 @@ requirements:
 
 
 test:
+  requires:
+    - pip
   imports:
     - keplergl
+  commands:
+    - pip check
 
 about:
   home: https://github.com/keplergl/kepler.gl
@@ -47,6 +52,7 @@ about:
     This is a simple jupyter widget for kepler.gl, an advanced geospatial
     visualization tool, to render large-scale interactive maps.
   doc_url: https://docs.kepler.gl/docs/keplergl-jupyter
+  dev_url: https://github.com/keplergl/kepler.gl/tree/master/bindings/kepler.gl-jupyter
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,29 +10,28 @@ source:
   sha256: 1762c4212f177843884ad51f74e06ee3efe58ea3711d0327b6aa99ccbed52815
 
 build:
-  noarch: python
   number: 0
   script:
     - {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<37]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - setuptools
     - pip
     - jupyter
     - jupyter-packaging
     - pandas
     - geopandas
+    - wheel
   run:
-    - python >=3.6
-    # build fails with most recent version
+    - python
     - ipywidgets ==7.8.1
     - traittypes >=0.2.1
     - pandas >=1.3.1
     - geopandas >=0.9.0
     - shapely >=1.7.1
-
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - python
     - setuptools
     - pip
-    - jupyter
     - jupyter-packaging
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python
     - setuptools
     - pip
-    - jupyter-packaging
+    - jupyter-packaging >=0.7.0,<0.8.0
     - wheel
   run:
     - python
@@ -29,6 +29,9 @@ requirements:
     - pandas >=0.23.0
     - geopandas >=0.5.0
     - shapely >=1.6.4.post2
+    
+  run_constrained:
+    - jupyterlab >=3.0.0
 
 test:
   requires:


### PR DESCRIPTION
keplergl 0.3.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4870]
- [Upstream repository](https://github.com/keplergl/kepler.gl/tree/v0.3.2-jupyter/bindings/kepler.gl-jupyter)

### Explanation of changes:

- Skip s390x due to missing `fiona`
- Dropped a few unused dependencies from host.
- No tests available for Python bindings.


[PKG-4870]: https://anaconda.atlassian.net/browse/PKG-4870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ